### PR TITLE
Update humam_tutorial.ipynb

### DIFF
--- a/humam_tutorial.ipynb
+++ b/humam_tutorial.ipynb
@@ -538,7 +538,7 @@
    "id": "b6746ea4-91bd-44f5-acb6-83df15b05480",
    "metadata": {},
    "source": [
-    "An overview of time-averaged firing rate over simulated populations encoded in colors with areas along horizontal axis and populations along vertical axis. Layers that are not present in the model for specific areas are represented by the \"X\" mark."
+    "An overview of time-averaged firing rate over simulated populations encoded in colors with areas along the horizontal axis and populations along the vertical axis. Layers that are not present in the model for specific areas are represented by the \"X\" mark."
    ]
   },
   {


### PR DESCRIPTION
This pull request includes a few updates to the `humam_tutorial.ipynb` file after @mlober reviewed it. The key changes involve adding explanatory markdown cells, correcting parameter descriptions, and updating references within the notebook.

Documentation improvements:
* Added a markdown cell explaining the importance of the `cc_scalingEtoE` parameter in transitioning network activity from the base to the best-fit version.
* Added a markdown cell noting the differences in mean firing rates between the downscaled and full-scale models.

Clarifications and corrections:
* Corrected the description of the `cc_scalingEtoE` parameter to specify its role in excitatory neurons.
* Updated a markdown cell to reference the correct parameter (`cc_scalingEtoE`) and provide context on its significance in network activity.
* Clarified the description of the time-averaged firing rate overview by specifying the axes.

To be addressed in next versions (Python packages will be updated in future and may solve the following warnings):
* warning when `yaml.load` is used
* warning related to array conversion when analysis.py is called 