### PR TITLE
Update scaling factor in humam_tutorial.ipynb

### DIFF
--- a/humam_tutorial.ipynb
+++ b/humam_tutorial.ipynb
@@ -161,7 +161,7 @@
    "source": [
     "# Set scaling parameters\n",
     "# value range/options: (0, 1.], change it to 1. to simulate the full-scale network\n",
-    "scaling_factor = 0.005\n",
+    "scaling_factor = 0.004\n",
     "\n",
     "# Scaling factor for cortico-cortical connections (Chi_E) to excitatory neurons.\n",
     "# Chi = 0.0 removes long-range cortico-cortical connections.\n",


### PR DESCRIPTION
This pull request includes a small change to the `humam_tutorial.ipynb` file. The change adjusts the scaling factor for the network simulation.

* [`humam_tutorial.ipynb`](diffhunk://#diff-da6b3ae2d423129db2ae99d3ccc00807dc0cee780063451429853db8545bdad6L164-R164): Changed the `scaling_factor` value from `0.005` to `0.004` to modify the network simulation parameters. This value is the limit to run on an EBRAINS free account (using max. 2 GB of RAM).