### PR TITLE
Small fix to package installation command in humam_tutorial.ipynb

### DIFF
--- a/humam_tutorial.ipynb
+++ b/humam_tutorial.ipynb
@@ -126,7 +126,7 @@
    "outputs": [],
    "source": [
     "# If using the Kernel EBRAINS-24.04, install the following missing packages. Otherwise, comment out the following line.\n",
-    "!pip install dicthash xlrd"
+    "!pip install dicthash nnmt"
    ]
   },
   {


### PR DESCRIPTION
This pull request includes a small change to the `humam_tutorial.ipynb` file. The change updates the list of packages to be installed, replacing `xlrd` with `nnmt`.

* [`humam_tutorial.ipynb`](diffhunk://#diff-da6b3ae2d423129db2ae99d3ccc00807dc0cee780063451429853db8545bdad6L129-R129): Updated the package installation command to replace `xlrd` with `nnmt`.