### PR TITLE
Jupyter tutorial: Update output path formatting and change notebook metadata kernel

### DIFF
--- a/humam_tutorial.ipynb
+++ b/humam_tutorial.ipynb
@@ -241,7 +241,9 @@
    "outputs": [],
    "source": [
     "# Get path to the output directory\n",
-    "net_params['outpath'] = os.path.join(os.getcwd(), 'out', 'downscaled'+str(scaling_factor))\n",
+    "net_params['outpath'] = os.path.join(\n",
+    "    os.getcwd(), 'out', 'downscaled'+str(scaling_factor)+'_cc'+str(net_params['cc_scalingEtoE'])\n",
+    "    )\n",
     "outpath = net_params['outpath']\n",
     "\n",
     "# Get base path\n",
@@ -736,9 +738,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "humam_nest3",
+   "display_name": "EBRAINS-24.04",
    "language": "python",
-   "name": "python3"
+   "name": "ebrains-24.04"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Updates to output directory path generation:

* Modified the `net_params['outpath']` assignment to include an additional component for `cc_scalingEtoE` in the directory path.

Updates to kernel specification:

* Changed the `display_name` and `name` fields in the notebook's metadata to use "EBRAINS-24.04". This will be updated once our package is included in the new kernel version.