### PR TITLE
Small fix to packages to be installed when running the tutorial on EBRAINS 24.04

### DIFF
--- a/humam_tutorial.ipynb
+++ b/humam_tutorial.ipynb
@@ -126,7 +126,7 @@
    "outputs": [],
    "source": [
     "# If using the Kernel EBRAINS-24.04, install the following missing packages. Otherwise, comment out the following line.\n",
-    "!pip install dicthash nnmt"
+    "!pip install dicthash nnmt xlrd"
    ]
   },
   {


### PR DESCRIPTION
This pull request includes an update to the `humam_tutorial.ipynb` file to ensure all necessary packages are installed for the tutorial.

* [`humam_tutorial.ipynb`](diffhunk://#diff-da6b3ae2d423129db2ae99d3ccc00807dc0cee780063451429853db8545bdad6L129-R129): Added the `xlrd` package to the list of packages to install, ensuring compatibility with the tutorial.