### PR TITLE
Correct bug on the parameter definition in the jupyter notebook tutorial

### DIFF
--- a/humam_tutorial.ipynb
+++ b/humam_tutorial.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# If using the Kernel EBRAINS-24.04, install the following missing packages. Otherwise, comment out the following line.\n",
+    "# If using the Kernel EBRAINS-24.04, install the following missing packages. Otherwise, comment the following line.\n",
     "!pip install dicthash nnmt xlrd"
    ]
   },
@@ -181,7 +181,7 @@
     "# Chi = 1.0 produces base version results in Pronold et al. (2024).\n",
     "# Chi = 2.5 produces best fit version results in Pronold et al. (2024).\n",
     "# obs: Chi to inhibitory neurons is set to 2.0 times the scaling factor for excitatory neurons.\n",
-    "net_params['cc_scalingEtoE'] = 1.0"
+    "cc_scalingEtoE = 1.0"
    ]
   },
   {
@@ -242,7 +242,7 @@
    "source": [
     "# Get path to the output directory\n",
     "net_params['outpath'] = os.path.join(\n",
-    "    os.getcwd(), 'out', 'downscaled'+str(scaling_factor)+'_cc'+str(net_params['cc_scalingEtoE'])\n",
+    "    os.getcwd(), 'out', 'downscaled'+str(scaling_factor)+'_cc'+str(cc_scalingEtoE)\n",
     "    )\n",
     "outpath = net_params['outpath']\n",
     "\n",
@@ -259,7 +259,8 @@
     "# Scaling factor for cortico-cortical connections (Chi) to inhibitory neurons.\n",
     "# it is set to 2.0 times the scaling factor for excitatory neurons.\n",
     "# This keeps the stability of the network.\n",
-    "net_params['cc_scalingEtoI'] = net_params['cc_scalingEtoE']*2.0\n",
+    "net_params['scaling_factors_recurrent']['cc_scalingEtoE'] = cc_scalingEtoE\n",
+    "net_params['scaling_factors_recurrent']['cc_scalingEtoI'] = cc_scalingEtoE*2.0\n",
     "\n",
     "# Set simulation parameters\n",
     "sim_params['t_sim'] = 2000.0        # Simulation time in ms\n",


### PR DESCRIPTION
A bug was found in the tutorial. The cc_scalingEtoE variable was being assigned in the wrong way. The `net_params['scaling_factors_recurrent']['cc_scalingEtoE']` was directly being set as `net_params['cc_scalingEtoE']`.
This PR only corrects that.